### PR TITLE
Update Goost information

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ I need the fracturing for my game but I thought I share it with anyone intereste
 
 
 ## Other Solutions
-- goost (https://github.com/goostengine/goost) for example, but requires building Godot from source
+- Goost (https://github.com/goostengine/goost), which can be downloaded at [Goost official website](https://goostengine.github.io/), otherwise requires building Godot from source.
 - Godot-3-2D-Destructible-Objects (https://github.com/hiulit/Godot-3-2D-Destructible-Objects) but only works for sprites


### PR DESCRIPTION
The "Other solutions" section mentions that using Goost requires building Godot from source, which is not the case because custom Godot + Goost builds can be downloaded from [Goost official website](https://goostengine.github.io/), otherwise it does require building Godot from source as of now.


I've stumbled upon the plugin and it's quite impressive. 🙂

By the way, the boolean operation functions were also contributed by myself in Godot: godotengine/godot#28987, so it's nice to see concrete projects that use those features, thanks!

---

For those stumbling upon this, [`PolyNode2D`](https://goost.readthedocs.io/en/latest/classes/class_polynode2d.html) is the class which allows to achieve destructible stuff in CSG-like way in Goost. See example project at https://github.com/goostengine/goost-examples/tree/gd3/2d/destructible_terrain.